### PR TITLE
Lex keywords distinctly from identifiers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,8 +29,7 @@ CheckOptions:
  - { key: readability-identifier-naming.MacroDefinitionCase,         value: UPPER_CASE           }
  - {key: readability-identifier-naming.MacroDefinitionIgnoredRegexp, value: '^[A-Z]+(_[A-Z]+)*_$'}
  - { key: readability-identifier-naming.EnumConstantCase,            value: UPPER_CASE           }
- - { key: readability-identifier-naming.GlobalConstantCase,          value: lower_case           }
- - { key: readability-identifier-naming.GlobalConstantPrefix,        value: k_                   }
+ - { key: readability-identifier-naming.GlobalConstantCase,          value: UPPER_CASE           }
  - { key: readability-identifier-naming.ConstantMemberCase,          value: lower_case           }
  - { key: readability-identifier-naming.ConstantMemberSuffix,        value: _                    }
  - { key: readability-identifier-naming.StaticConstantCase,          value: lower_case           }

--- a/src/common.h
+++ b/src/common.h
@@ -3,4 +3,6 @@
 
 #define FORT_UNUSED(x) (void)(x)
 
+#define NELEM(x) (sizeof(x) / sizeof((x)[0]))
+
 #endif // FORT_COMMON_H

--- a/src/lex.h
+++ b/src/lex.h
@@ -9,7 +9,7 @@ typedef struct lexer lexer_t;
 typedef enum {
     TOKT_IDENTIFIER,
     TOKT_CONSTANT,
-    TOKT_KEYWORD_INT,
+    TOKT_KEYWORD_I32,
     TOKT_KEYWORD_VOID,
     TOKT_KEYWORD_RETURN,
     TOKT_OPEN_PAREN,

--- a/test/lex_test.c
+++ b/test/lex_test.c
@@ -75,11 +75,7 @@ TEST(test_identifier, {
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
-    TEST_ASSERT_TRUE(lexeme_equals(tok, "ABC_"));
-
-    tok = tok->next;
-    TEST_ASSERT_EQ_INT32(tok->type, TOKT_CONSTANT);
-    TEST_ASSERT_TRUE(lexeme_equals(tok, "123"));
+    TEST_ASSERT_TRUE(lexeme_equals(tok, "ABC_123"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
@@ -136,13 +132,13 @@ TEST(test_whitespace_handling, {
 })
 
 TEST(test_simple_function, {
-    const char* src = "int main() { return 0; }";
+    const char* src = "i32 main() { return 0; }";
     lexer_t* lexer = mklexer(src, strlen(src));
     tok_t* tokens = lexer_run(lexer);
 
     tok_t* tok = tokens;
-    TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
-    TEST_ASSERT_TRUE(lexeme_equals(tok, "int"));
+    TEST_ASSERT_EQ_INT32(tok->type, TOKT_KEYWORD_I32);
+    TEST_ASSERT_TRUE(lexeme_equals(tok, "i32"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
@@ -158,7 +154,7 @@ TEST(test_simple_function, {
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_OPEN_BRACE);
 
     tok = tok->next;
-    TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
+    TEST_ASSERT_EQ_INT32(tok->type, TOKT_KEYWORD_RETURN);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "return"));
 
     tok = tok->next;


### PR DESCRIPTION
fort embeds the bit width of integer types into the type name, so drop support for int and use i32 instead.