### PR TITLE
ch1: Implement parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,17 +82,28 @@ if(FORT_UBSAN_ENABLED)
     message(STATUS "UndefinedBehaviorSanitizer enabled")
 endif()
 
-# Fort compiler executable
-add_executable(fort
-    ${FORT_SRC_DIR}/fort.c
+function(sanitizer_flags TARGET)
+if(SANITIZER_FLAGS)
+    target_compile_options(${TARGET} PRIVATE ${SANITIZER_FLAGS})
+    target_link_options(${TARGET} PRIVATE ${SANITIZER_LINK_FLAGS})
+endif()
+endfunction()
+
+set(FORT_SRC_LIST
     ${FORT_SRC_DIR}/lex.c
+    ${FORT_SRC_DIR}/parse.c
 )
 
-# Apply sanitizer flags if any are enabled
-if(SANITIZER_FLAGS)
-    target_compile_options(fort PRIVATE ${SANITIZER_FLAGS})
-    target_link_options(fort PRIVATE ${SANITIZER_LINK_FLAGS})
-endif()
+add_library(fort-lib ${FORT_SRC_LIST})
+target_include_directories(fort-lib PRIVATE ${FORT_SRC_DIR})
+set_target_properties(fort-lib PROPERTIES OUTPUT_NAME fort)
+sanitizer_flags(fort-lib)
+
+# Fort compiler executable
+add_executable(fort ${FORT_SRC_DIR}/fort.c)
+target_include_directories(fort PRIVATE ${FORT_SRC_DIR})
+target_link_libraries(fort fort-lib)
+sanitizer_flags(fort)
 
 file(GLOB_RECURSE 
     HDR_FILES

--- a/src/common.h
+++ b/src/common.h
@@ -2,7 +2,7 @@
 #define FORT_COMMON_H
 
 #include <stdarg.h>  // for va_end, va_list, va_start
-#include <stdio.h>   // for fprintf, stderr, vfprintf
+#include <stdio.h>   // for fprintf, stderr, vfprintf, size_t
 
 #define FORT_UNUSED(x) (void)(x)
 
@@ -20,5 +20,24 @@ static inline void eprintln(const char* fmt, ...) {
     va_end(args);
     FORT_UNUSED(fprintf(stderr, "\n"));
 }
+
+typedef enum {
+    FORT_OUTCOME_OK,
+    FORT_OUTCOME_ERR,
+    FORT_OUTCOME_FATAL,
+} fort_outcome_t;
+
+#define FORT_OUTCOME_NOK_RET(expr)                                                                 \
+    {                                                                                              \
+        fort_outcome_t outcome__ = (expr);                                                         \
+        if (outcome__ != FORT_OUTCOME_OK) {                                                        \
+            return outcome__;                                                                      \
+        }                                                                                          \
+    }
+
+typedef struct {
+    const char* p;
+    size_t len;
+} buf_t;
 
 #endif // FORT_COMMON_H

--- a/src/lex.c
+++ b/src/lex.c
@@ -1,11 +1,12 @@
 #include "lex.h"
 
-#include <stddef.h>  // for NULL, size_t
-#include <stdint.h>  // for uint32_t
-#include <stdlib.h>  // for free, malloc
-#include <string.h>  // for strncmp
+#include <stdbool.h>  // for bool
+#include <stddef.h>   // for NULL, size_t
+#include <stdint.h>   // for uint32_t
+#include <stdlib.h>   // for free, malloc
+#include <string.h>   // for strncmp
 
-#include "common.h"  // for FORT_UNUSED, NELEM
+#include "common.h"   // for FORT_UNUSED, FORT_OUTCOME_ERR, FORT_OUTCOME_OK
 
 typedef struct {
     const char* lexeme;
@@ -179,9 +180,8 @@ void lexer_fini(lexer_t* lexer) {
     free(lexer);
 }
 
-tok_stream_t lexer_run(lexer_t* lexer) {
-    tok_stream_t stream = {0};
-    tok_t* ip = &stream.head;
+fort_outcome_t lexer_run(lexer_t* lexer, tok_stream_t* toks) {
+    tok_t* ip = &toks->head;
 
     for (;;) {
         tok_t* tok = malloc(sizeof(tok_t));
@@ -190,7 +190,7 @@ tok_stream_t lexer_run(lexer_t* lexer) {
         ip = ip->next;
 
         if (tok->type == TOKT_ERROR) {
-            stream.err = true;
+            return FORT_OUTCOME_ERR;
         }
 
         if (tok->type == TOKT_EOF) {
@@ -198,7 +198,9 @@ tok_stream_t lexer_run(lexer_t* lexer) {
         }
     }
 
-    return stream;
+    toks->next = toks->head.next;
+
+    return FORT_OUTCOME_OK;
 }
 
 void tok_stream_fini(tok_stream_t* toks) {

--- a/src/lex.h
+++ b/src/lex.h
@@ -1,9 +1,10 @@
 #ifndef FORT_LEX_H
 #define FORT_LEX_H
 
-#include <stdbool.h>  // for bool
-#include <stddef.h>   // for size_t
-#include <stdint.h>   // for uint32_t
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for uint32_t
+
+#include "common.h"  // for buf_t, fort_outcome_t
 
 typedef struct lexer lexer_t;
 
@@ -25,23 +26,20 @@ typedef enum {
 typedef struct tok {
     tokt_t type;
     uint32_t line;
-    struct {
-        const char* p;
-        size_t len;
-    } lexeme;
+    buf_t lexeme;
     struct tok* next;
 } tok_t;
 
 typedef struct {
     tok_t head;
-    bool err;
+    tok_t* next;
 } tok_stream_t;
 
 lexer_t* mklexer(const char* src, size_t len);
 
 void lexer_fini(lexer_t* lexer);
 
-tok_stream_t lexer_run(lexer_t* lexer);
+fort_outcome_t lexer_run(lexer_t* lexer, tok_stream_t* toks);
 
 void tok_stream_fini(tok_stream_t* tok);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,0 +1,199 @@
+#include "parse.h"
+
+#include <inttypes.h>  // for int32_t, INT32_MAX
+#include <stdlib.h>    // for NULL, free, malloc, size_t
+
+#include "lex.h"       // for tok_stream_t, tok_t, TOKT_CLOSE_BRACE, TOKT_CL...
+
+typedef enum {
+    AST_NODE_PROG,
+    AST_NODE_FUNC,
+    AST_NODE_STMT,
+    AST_NODE_EXPR,
+} ast_node_kind_t;
+
+typedef struct {
+    union {
+        prog_t prog;
+        func_t func;
+        stmt_t stmt;
+        expr_t expr;
+    } u;
+    ast_node_kind_t kind;
+} ast_node_t;
+
+struct parser {
+    tok_stream_t* toks;
+};
+
+static fort_outcome_t consume_tok(tok_stream_t* toks, tok_t* tok) {
+    if (toks == NULL) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    if (toks->next == NULL) {
+        return FORT_OUTCOME_ERR;
+    }
+
+    if (tok != NULL) {
+        *tok = *toks->next;
+    }
+
+    toks->next = toks->next->next;
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t expect(tok_stream_t* toks, tokt_t type, tok_t* tok_out) {
+    tok_t tok = {0};
+    fort_outcome_t outcome = consume_tok(toks, &tok);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    if (tok.type != type) {
+        return FORT_OUTCOME_ERR;
+    }
+
+    if (tok_out != NULL) {
+        *tok_out = tok;
+    }
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_int32(const char* p, size_t len, int32_t* num) {
+    const int parse_base = 10;
+    if (len == 0) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    int32_t result = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (p[i] < '0' || p[i] > '9') {
+            return FORT_OUTCOME_FATAL;
+        }
+
+        // Check for overflow before multiplication
+        if (result > INT32_MAX / parse_base) {
+            return FORT_OUTCOME_ERR;
+        }
+        result *= parse_base;
+
+        int32_t digit = p[i] - '0';
+
+        // Check for overflow before addition
+        if (result > (INT32_MAX - digit)) {
+            return FORT_OUTCOME_ERR;
+        }
+
+        result += digit;
+    }
+
+    *num = result;
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_expr(tok_stream_t* toks, expr_t* expr) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+    tok_t tok = {0};
+    outcome = expect(toks, TOKT_CONSTANT, &tok);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = parse_int32(tok.lexeme.p, tok.lexeme.len, &expr->u.constant.val);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    expr->kind = EXPR_CONST;
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_stmt(tok_stream_t* toks, stmt_t* stmt) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+    outcome = expect(toks, TOKT_KEYWORD_RETURN, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+    stmt->kind = STMT_RET;
+
+    outcome = parse_expr(toks, &stmt->u.ret.expr);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_SEMICOLON, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_func(tok_stream_t* toks, func_t* func) {
+    fort_outcome_t outcome = FORT_OUTCOME_ERR;
+
+    outcome = expect(toks, TOKT_KEYWORD_I32, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    tok_t ident = {0};
+    outcome = expect(toks, TOKT_IDENTIFIER, &ident);
+    FORT_OUTCOME_NOK_RET(outcome);
+    func->name = ident.lexeme;
+
+    outcome = expect(toks, TOKT_OPEN_PAREN, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_KEYWORD_VOID, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_CLOSE_PAREN, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_OPEN_BRACE, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = parse_stmt(toks, &func->body);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_CLOSE_BRACE, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_prog(tok_stream_t* toks, prog_t* prog) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
+    if (prog == NULL) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    outcome = parse_func(toks, &prog->func);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    outcome = expect(toks, TOKT_EOF, NULL);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    return FORT_OUTCOME_OK;
+}
+
+parser_t* mkparser(tok_stream_t* toks) {
+    parser_t* parser = malloc(sizeof(parser_t));
+    parser->toks = toks;
+
+    return parser;
+}
+
+void parser_fini(parser_t* parser) {
+    free(parser);
+}
+
+fort_outcome_t parser_run(parser_t* parser, prog_t* prog) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
+    if (parser == NULL) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    if (prog == NULL) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    outcome = parse_prog(parser->toks, prog);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    return FORT_OUTCOME_OK;
+}

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,0 +1,52 @@
+#ifndef FORT_PARSE_H
+#define FORT_PARSE_H
+
+#include <inttypes.h>  // for int32_t
+
+#include "common.h"    // for buf_t, fort_outcome_t
+#include "lex.h"       // for tok_stream_t
+
+typedef struct parser parser_t;
+
+typedef enum {
+    EXPR_CONST,
+} expr_kind_t;
+
+typedef struct {
+    union {
+        struct {
+            int32_t val;
+        } constant;
+    } u;
+    expr_kind_t kind;
+} expr_t;
+
+typedef enum {
+    STMT_RET,
+} stmt_kind_t;
+
+typedef struct {
+    union {
+        struct {
+            expr_t expr;
+        } ret;
+    } u;
+    stmt_kind_t kind;
+} stmt_t;
+
+typedef struct {
+    buf_t name;
+    stmt_t body;
+} func_t;
+
+typedef struct {
+    func_t func;
+} prog_t;
+
+parser_t* mkparser(tok_stream_t* toks);
+
+void parser_fini(parser_t* parser);
+
+fort_outcome_t parser_run(parser_t* parser, prog_t* prog);
+
+#endif // FORT_PARSE_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,11 @@
-# Test configuration
+function(fort_test TEST_NAME)
+    file(GLOB TEST_FILE "${FORT_TEST_DIR}/${TEST_NAME}.c*")
+    add_executable(${TEST_NAME} ${TEST_FILE})
+    target_include_directories(${TEST_NAME} PRIVATE ${FORT_SRC_DIR})
+    target_link_libraries(${TEST_NAME} PRIVATE fort-lib)
+    sanitizer_flags(${TEST_NAME})
+    add_test(${TEST_NAME} ${TEST_NAME})
+endfunction()
 
-# Lexer tests
-add_executable(lex_test
-    lex_test.c
-    ${FORT_SRC_DIR}/lex.c
-)
-
-target_include_directories(lex_test PRIVATE ${FORT_SRC_DIR})
-
-add_test(NAME lex_test COMMAND lex_test)
+fort_test(lex_test)
+fort_test(parse_test)

--- a/test/cli-test.sh
+++ b/test/cli-test.sh
@@ -9,6 +9,6 @@ CLI_TESTS=$CLI_TESTS_DIR/test_compiler
 FORT="$PROJECT_ROOT"/build/fort
 
 CHAPTER=1
-STAGE=lex
+STAGE=parse
 
 $CLI_TESTS $FORT --chapter $CHAPTER --stage $STAGE

--- a/test/lex_test.c
+++ b/test/lex_test.c
@@ -1,9 +1,10 @@
 #include "lex.h"
 
-#include <stddef.h>  // for NULL, size_t
-#include <string.h>  // for strlen, strncmp
+#include <stdbool.h>  // for bool
+#include <stddef.h>   // for NULL, size_t
+#include <string.h>   // for strlen, strncmp
 
-#include "test.h"    // for TEST_ASSERT_EQ_INT32, TEST_ASSERT_TRUE, TEST
+#include "test.h"     // for TEST_ASSERT_EQ_INT32, TEST_ASSERT_TRUE, TEST
 
 static bool lexeme_equals(const tok_t* tok, const char* expected) {
     size_t expected_len = strlen(expected);
@@ -13,42 +14,47 @@ static bool lexeme_equals(const tok_t* tok, const char* expected) {
 TEST(empty_input, {
     const char* src = "";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_NONNULL(tok);
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
     TEST_ASSERT_TRUE(tok->next == NULL);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(single_constant, {
     const char* src = "42";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_NONNULL(tok);
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_CONSTANT);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "42"));
     TEST_ASSERT_NONNULL(tok->next);
     TEST_ASSERT_EQ_INT32(tok->next->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(multiple_constants, {
     const char* src = "123 456 789";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_CONSTANT);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "123"));
 
@@ -63,17 +69,19 @@ TEST(multiple_constants, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(identifier, {
     const char* src = "foo bar_baz ABC_123";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "foo"));
 
@@ -88,17 +96,19 @@ TEST(identifier, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(punctuation, {
     const char* src = "(){};";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_OPEN_PAREN);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "("));
 
@@ -117,17 +127,19 @@ TEST(punctuation, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(whitespace_handling, {
     const char* src = "  \t\n  42  \n\n  foo  \t";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_CONSTANT);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "42"));
     TEST_ASSERT_EQ_INT32(tok->line, 2);
@@ -140,17 +152,19 @@ TEST(whitespace_handling, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(simple_function, {
     const char* src = "i32 main() { return 0; }";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_KEYWORD_I32);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "i32"));
 
@@ -184,31 +198,34 @@ TEST(simple_function, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(invalid_constant_with_letter, {
     const char* src = "123abc";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_NONNULL(tok);
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_ERROR);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(line_tracking, {
     const char* src = "foo\nbar\n\nbaz";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_EQ_INT32(tok->line, 1);
 
@@ -220,34 +237,37 @@ TEST(line_tracking, {
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_EQ_INT32(tok->line, 4);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(mixed_tokens, {
     const char* src = "x = 42 + y;";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "x"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_ERROR);  // '=' not yet supported
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(single_line_comment, {
     const char* src = "42 // this is a comment\n99";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_CONSTANT);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "42"));
 
@@ -258,51 +278,57 @@ TEST(single_line_comment, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(comment_at_start, {
     const char* src = "// comment at start\nfoo";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "foo"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(comment_at_end, {
     const char* src = "bar // comment at end";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "bar"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(multiple_comments, {
     const char* src = "// first comment\nx // second\n// third\ny";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "x"));
     TEST_ASSERT_EQ_INT32(tok->line, 2);
@@ -315,24 +341,26 @@ TEST(multiple_comments, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(comment_with_code_like_content, {
     const char* src = "// int x = 42; return foo;\nactual";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "actual"));
 
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
@@ -342,10 +370,12 @@ TEST(function_with_comments, {
                       "    return 0; // success\n"
                       "}";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_KEYWORD_I32);
 
     tok = tok->next;
@@ -377,17 +407,19 @@ TEST(function_with_comments, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 
 TEST(empty_comment, {
     const char* src = "foo //\nbar";
     lexer_t* lexer = mklexer(src, strlen(src));
-    tok_stream_t stream = lexer_run(lexer);
+    tok_stream_t toks = {0};
+    fort_outcome_t outcome = lexer_run(lexer, &toks);
 
-    TEST_ASSERT_TRUE(!stream.err);
-    tok_t* tok = stream.head.next;
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    tok_t* tok = toks.head.next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_IDENTIFIER);
     TEST_ASSERT_TRUE(lexeme_equals(tok, "foo"));
 
@@ -398,7 +430,7 @@ TEST(empty_comment, {
     tok = tok->next;
     TEST_ASSERT_EQ_INT32(tok->type, TOKT_EOF);
 
-    tok_stream_fini(&stream);
+    tok_stream_fini(&toks);
     lexer_fini(lexer);
 })
 

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -1,0 +1,361 @@
+#include "parse.h"
+
+#include <stddef.h>  // for NULL
+#include <string.h>  // for strlen
+
+#include "lex.h"     // for lexer_fini, lexer_run, mklexer, tok_stream_fini
+#include "test.h"    // for TEST_ASSERT_EQ_INT32, TEST, TEST_RUN, TEST_EXIT
+
+TEST(simple_program, {
+    const char* src = "i32 main(void) { return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 0);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(return_42, {
+    const char* src = "i32 main(void) { return 42; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 42);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(return_large_number, {
+    const char* src = "i32 main(void) { return 2147483647; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 2147483647);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(overflow_constant, {
+    const char* src = "i32 main(void) { return 2147483648; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(with_whitespace, {
+    const char* src = "  i32   main  (  void  )  {  return   100  ;  }  ";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 100);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(with_comments, {
+    const char* src = "// This is a comment\n"
+                      "i32 main(void) { // main function\n"
+                      "    return 42; // return value\n"
+                      "}\n";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 42);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(multiline_program, {
+    const char* src = "i32 main(void) {\n"
+                      "    return 7;\n"
+                      "}\n";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 7);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_return_keyword, {
+    const char* src = "i32 main(void) { 42; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_semicolon, {
+    const char* src = "i32 main(void) { return 42 }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);  // propagates outcome from expect
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_expression, {
+    const char* src = "i32 main(void) { return ; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_open_brace, {
+    const char* src = "i32 main(void) return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_close_brace, {
+    const char* src = "i32 main(void) { return 0;";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_void_keyword, {
+    const char* src = "i32 main() { return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(wrong_return_type, {
+    const char* src = "void main(void) { return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(missing_function_name, {
+    const char* src = "i32 (void) { return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(empty_input, {
+    const char* src = "";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(null_parser, {
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(NULL, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_FATAL);
+})
+
+TEST(null_prog, {
+    const char* src = "i32 main(void) { return 0; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    fort_outcome_t outcome = parser_run(parser, NULL);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_FATAL);
+
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+int main(int argc, char* argv[]) {
+    TEST_INIT("parse", argc, argv);
+
+    TEST_RUN(simple_program);
+    TEST_RUN(return_42);
+    TEST_RUN(return_large_number);
+    TEST_RUN(overflow_constant);
+    TEST_RUN(with_whitespace);
+    TEST_RUN(with_comments);
+    TEST_RUN(multiline_program);
+    TEST_RUN(missing_return_keyword);
+    TEST_RUN(missing_semicolon);
+    TEST_RUN(missing_expression);
+    TEST_RUN(missing_open_brace);
+    TEST_RUN(missing_close_brace);
+    TEST_RUN(missing_void_keyword);
+    TEST_RUN(wrong_return_type);
+    TEST_RUN(missing_function_name);
+    TEST_RUN(empty_input);
+    TEST_RUN(null_parser);
+    TEST_RUN(null_prog);
+
+    TEST_EXIT();
+}

--- a/test/test.h
+++ b/test/test.h
@@ -2,7 +2,7 @@
 #define FORT_TEST_H
 
 #include <inttypes.h>  // for PRId32, PRId64
-#include <stdbool.h>   // for true, false
+#include <stdbool.h>   // for false, true
 #include <stdio.h>     // for NULL
 #include <string.h>    // for strlen, strncmp
 


### PR DESCRIPTION
Besides implementing the parser and hooking it into the compiler tool, the following changes are worth noting:
- Move toward an "outcome" based API where an operation returns its outcome and mutates state via an output variable.
- Compile test binaries with sanitizers.