### PR TITLE
Implement a multi-level logger

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,21 +20,21 @@ Checks: >
 WarningsAsErrors: "*"
 
 CheckOptions:
- - { key: readability-identifier-naming.NamespaceCase,                value: lower_case                  }
- - { key: readability-identifier-naming.TemplateParameterCase,        value: CamelCase                   }
- - { key: readability-identifier-naming.FunctionCase,                 value: lower_case                  }
- - { key: readability-identifier-naming.FunctionIgnoredRegexp,        value: 'ARG.*'                     }
- - { key: readability-identifier-naming.VariableCase,                 value: lower_case                  }
- - { key: readability-identifier-naming.PrivateMemberSuffix,          value: _                           }
- - { key: readability-identifier-naming.ProtectedMemberSuffix,        value: _                           }
- - { key: readability-identifier-naming.MacroDefinitionCase,          value: UPPER_CASE                  }
- - { key: readability-identifier-naming.MacroDefinitionIgnoredRegexp, value: '^[A-Z]+(_[A-Z]+)*_$|FMT.*' }
- - { key: readability-identifier-naming.EnumConstantCase,             value: UPPER_CASE                  }
- - { key: readability-identifier-naming.GlobalConstantCase,           value: UPPER_CASE                  }
- - { key: readability-identifier-naming.ConstantMemberCase,           value: lower_case                  }
- - { key: readability-identifier-naming.ConstantMemberSuffix,         value: _                           }
- - { key: readability-identifier-naming.StaticConstantCase,           value: lower_case                  }
-
+ - { key: readability-identifier-naming.NamespaceCase,                value: lower_case                        }
+ - { key: readability-identifier-naming.TemplateParameterCase,        value: CamelCase                         }
+ - { key: readability-identifier-naming.FunctionCase,                 value: lower_case                        }
+ - { key: readability-identifier-naming.FunctionIgnoredRegexp,        value: 'ARG.*'                           }
+ - { key: readability-identifier-naming.VariableCase,                 value: lower_case                        }
+ - { key: readability-identifier-naming.PrivateMemberSuffix,          value: _                                 }
+ - { key: readability-identifier-naming.ProtectedMemberSuffix,        value: _                                 }
+ - { key: readability-identifier-naming.MacroDefinitionCase,          value: UPPER_CASE                        }
+ - { key: readability-identifier-naming.MacroDefinitionIgnoredRegexp, value: '^[A-Z]+(_[A-Z]+)*_$|FMT.*|ARG.*' }
+ - { key: readability-identifier-naming.EnumConstantCase,             value: UPPER_CASE                        }
+ - { key: readability-identifier-naming.GlobalConstantCase,           value: UPPER_CASE                        }
+ - { key: readability-identifier-naming.ConstantMemberCase,           value: lower_case                        }
+ - { key: readability-identifier-naming.ConstantMemberSuffix,         value: _                                 }
+ - { key: readability-identifier-naming.StaticConstantCase,           value: lower_case                        }
+      
  - { key: bugprone-unused-return-value.CheckedFunctions,   value: '^.*$' }
  - { key: bugprone-unused-return-value.CheckedReturnTypes, value: '^.*$' }
  - { key: bugprone-unused-return-value.AllowCastToVoid,    value:  true  }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,14 +98,13 @@ set(FORT_SRC_LIST
 add_library(fort-lib ${FORT_SRC_LIST})
 target_include_directories(fort-lib PRIVATE ${FORT_SRC_DIR})
 set_target_properties(fort-lib PROPERTIES OUTPUT_NAME fort)
-target_compile_definitions(fort-lib PUBLIC _XOPEN_SOURCE=700)
+target_compile_definitions(fort-lib PUBLIC _GNU_SOURCE)
 sanitizer_flags(fort-lib)
 
 # Fort compiler executable
 add_executable(fort ${FORT_SRC_DIR}/fort.c)
 target_include_directories(fort PRIVATE ${FORT_SRC_DIR})
 target_link_libraries(fort fort-lib)
-target_compile_definitions(fort PRIVATE _XOPEN_SOURCE=700)
 sanitizer_flags(fort)
 
 file(GLOB_RECURSE 

--- a/src/common.h
+++ b/src/common.h
@@ -4,9 +4,9 @@
 #include <errno.h>     // for errno
 #include <limits.h>    // for PATH_MAX
 #include <stdarg.h>    // for va_end, va_list, va_start
-#include <stdio.h>     // for size_t, fprintf, snprintf, stderr, vfprintf, NULL
+#include <stdio.h>     // for fprintf, size_t, stderr, snprintf, vfprintf, NULL
 #include <stdlib.h>    // for getenv, mkstemp
-#include <string.h>    // for memcpy
+#include <string.h>    // for strerrorname_np, memcpy
 #include <unistd.h>    // for close
 #include <sys/stat.h>  // for stat
 
@@ -38,10 +38,7 @@ typedef struct {
     size_t len;
 } filepath_t;
 
-static inline void eprintln(const char* fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-
+static inline void veprintln(const char* fmt, va_list args) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
     FORT_UNUSED(vfprintf(stderr, fmt, args));
@@ -50,6 +47,62 @@ static inline void eprintln(const char* fmt, ...) {
     va_end(args);
     FORT_UNUSED(fprintf(stderr, "\n"));
 }
+
+static inline void eprintln(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    veprintln(fmt, args);
+    va_end(args);
+}
+
+typedef enum {
+    LOG_DEBUG,
+    LOG_INFO,
+    LOG_ERROR,
+    LOG_FATAL,
+
+} fort_log_level_t;
+
+static inline const char* ARGlog_level(fort_log_level_t level) {
+    switch (level) {
+
+    case LOG_DEBUG:
+        return "debug";
+    case LOG_INFO:
+        return "info";
+    case LOG_ERROR:
+        return "error";
+    case LOG_FATAL:
+        return "fatal";
+    default:
+        return "unknown";
+    }
+}
+static inline void fort_log(fort_log_level_t level, const char* fmt, ...) {
+#ifndef NDEBUG
+    if (level == LOG_DEBUG) {
+        return;
+    }
+#endif
+    FORT_UNUSED(fprintf(stderr, "%s: ", ARGlog_level(level)));
+    va_list args;
+    va_start(args, fmt);
+    veprintln(fmt, args);
+    va_end(args);
+}
+
+#define FMTerrno "errno=%s"
+
+#define ARGerrno strerrorname_np(errno)
+
+#define FORT_CLOSE(fd, filepath)                                                                   \
+    {                                                                                              \
+        int res = close(fd);                                                                       \
+        if (res < 0) {                                                                             \
+            fort_log(                                                                              \
+                LOG_ERROR, "could not close file: %s. %s:%d", (filepath), __FILE__, __LINE__);     \
+        }                                                                                          \
+    }
 
 static inline fort_outcome_t tmp_file(filepath_t* filepath) {
     const char* tmp_dir = getenv("TMPDIR");
@@ -64,18 +117,22 @@ static inline fort_outcome_t tmp_file(filepath_t* filepath) {
     char template[PATH_MAX];
     int needed = snprintf(template, NELEM(template), "%s/fort_XXXXXX", tmp_dir);
     if (needed < 0) {
-        eprintln("could not produce temp file template %d", errno);
+        fort_log(LOG_FATAL, "could not produce temp file template: " FMTerrno, ARGerrno);
         return FORT_OUTCOME_FATAL;
     }
 
     size_t len = (size_t)needed;
-    if (len >= NELEM(template)) {
+    if (len > NELEM(template)) {
+        fort_log(LOG_FATAL,
+                 "insufficient buffer for temporary file name: %zu vs %zu",
+                 len,
+                 NELEM(template));
         return FORT_OUTCOME_FATAL;
     }
 
     int fd = mkstemp(template);
     if (fd == -1) {
-        eprintln("could not create temp file %d", errno);
+        fort_log(LOG_FATAL, "could create temp file: " FMTerrno, ARGerrno);
         return FORT_OUTCOME_FATAL;
     }
 

--- a/src/fort.c
+++ b/src/fort.c
@@ -1,15 +1,14 @@
 #include <fcntl.h>     // for open, O_RDONLY
 #include <getopt.h>    // for no_argument, getopt_long, option
 #include <stdint.h>    // for uint64_t
-#include <stdio.h>     // for perror, size_t
-#include <stdlib.h>    // for EXIT_FAILURE, EXIT_SUCCESS, free, NULL, exit
+#include <stdlib.h>    // for EXIT_FAILURE, EXIT_SUCCESS, free, size_t, NULL
 #include <string.h>    // for memcpy, strlen
-#include <unistd.h>    // for NULL, close, execvp, fork, optind, pread, off_t
+#include <unistd.h>    // for NULL, execvp, fork, optind, pread, off_t, pid_t
 #include <sys/stat.h>  // for stat, fstat
 #include <sys/wait.h>  // for waitpid
 
 #include "assemble.h"  // for asm_prog_t, asm_prog_fini, assembler_fini, ass...
-#include "common.h"    // for eprintln, FORT_OUTCOME_OK, fort_outcome_t, FOR...
+#include "common.h"    // for fort_log, FORT_OUTCOME_OK, LOG_ERROR, eprintln
 #include "lex.h"       // for tok_stream_fini, tok_stream_t, lexer_fini, lex...
 #include "parse.h"     // for prog_t, mkparser, parser_fini, parser_run, par...
 
@@ -20,7 +19,7 @@ typedef enum {
     STAGE_COMPILE,
 } stage_t;
 
-#define FMTstage "STAGE(%s)"
+#define FMTstage "STAGE=%s"
 
 static inline const char* ARGstage(stage_t stage) {
     switch (stage) {
@@ -40,28 +39,29 @@ static inline const char* ARGstage(stage_t stage) {
 static char* load_src(const char* filepath) {
     int fd = open(filepath, O_RDONLY);
     if (fd < 0) {
-        perror("open");
+        fort_log(LOG_ERROR, "could not open file %s: " FMTerrno, filepath, ARGerrno);
         return NULL;
     }
 
     struct stat st;
     if (fstat(fd, &st) < 0) {
-        perror("fstat");
-        FORT_UNUSED(close(fd));
+        fort_log(LOG_ERROR, "could not stat file %s: " FMTerrno, filepath, ARGerrno);
+        FORT_CLOSE(fd, filepath);
         return NULL;
     }
 
     if (st.st_size < 0) {
-        eprintln("error: unexpected file size: %zd", st.st_size);
-        FORT_UNUSED(close(fd));
+        fort_log(LOG_ERROR, "unexpected size for file %s: %zd", filepath, st.st_size);
+        FORT_CLOSE(fd, filepath);
         return NULL;
     }
 
     size_t file_sz = (size_t)st.st_size;
     char* src = malloc(file_sz + 1);
     if (src == NULL) {
-        perror("malloc");
-        FORT_UNUSED(close(fd));
+        fort_log(
+            LOG_ERROR, "could not allocate memory for file %s: ", FMTerrno, filepath, ARGerrno);
+        FORT_CLOSE(fd, filepath);
         return NULL;
     }
     src[file_sz] = '\0';
@@ -71,16 +71,16 @@ static char* load_src(const char* filepath) {
     while (nbytes_rem > 0) {
         ssize_t nbytes = pread(fd, src + off, nbytes_rem, off);
         if (nbytes < 0) {
-            perror("pread");
+            fort_log(LOG_ERROR, "could not read file %s: " FMTerrno, filepath, ARGerrno);
             free(src);
-            FORT_UNUSED(close(fd));
+            FORT_CLOSE(fd, filepath);
             return NULL;
         }
         nbytes_rem -= (size_t)nbytes;
         off += nbytes;
     }
 
-    FORT_UNUSED(close(fd));
+    FORT_CLOSE(fd, filepath);
 
     return src;
 }
@@ -133,7 +133,7 @@ static fort_outcome_t stage_lex(const char* src, tok_stream_t* toks) {
     fort_outcome_t outcome = lexer_run(lexer, toks);
     lexer_fini(lexer);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to lex source file");
+        fort_log(LOG_ERROR, "failed to lex source file");
 
         return outcome;
     }
@@ -153,7 +153,7 @@ static fort_outcome_t stage_parse(const char* src, prog_t* prog) {
     parser_fini(parser);
     tok_stream_fini(&toks);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to parse source file");
+        fort_log(LOG_ERROR, "failed to parse source file");
 
         return outcome;
     }
@@ -173,7 +173,7 @@ static fort_outcome_t stage_codegen(const char* src, asm_prog_t* asm_prog) {
     assembler_fini(assembler);
 
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to generate assembly");
+        fort_log(LOG_ERROR, "failed to generate assembly");
 
         return outcome;
     }
@@ -184,7 +184,7 @@ static fort_outcome_t stage_codegen(const char* src, asm_prog_t* asm_prog) {
 static fort_outcome_t assemble_and_link(const filepath_t* asm_file, const filepath_t* out_file) {
     pid_t pid = fork();
     if (pid == -1) {
-        eprintln("could not fork process");
+        fort_log(LOG_FATAL, "could not fork process");
         return FORT_OUTCOME_FATAL;
     }
 
@@ -207,7 +207,7 @@ static fort_outcome_t assemble_and_link(const filepath_t* asm_file, const filepa
 #pragma GCC diagnostic pop
 
         if (execvp("clang", args) == -1) {
-            eprintln("error: could not execute clang");
+            fort_log(LOG_FATAL, "could not execute clang");
             exit(EXIT_FAILURE);
         }
     } else {
@@ -225,7 +225,7 @@ static fort_outcome_t stage_compile(const char* src, const filepath_t* out_file)
     asm_prog_t prog = {0};
     fort_outcome_t outcome = stage_codegen(src, &prog);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to generate assembly");
+        fort_log(LOG_ERROR, "failed to generate assembly");
 
         return outcome;
     }
@@ -233,19 +233,19 @@ static fort_outcome_t stage_compile(const char* src, const filepath_t* out_file)
     filepath_t asm_file = {0};
     outcome = tmp_file(&asm_file);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: could not create temporary assembly file");
+        fort_log(LOG_ERROR, "could not create temporary assembly file");
     }
 
     outcome = emit_asm(&prog, &asm_file);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to emit assembly");
+        fort_log(LOG_ERROR, "failed to emit assembly");
 
         return outcome;
     }
 
     outcome = assemble_and_link(&asm_file, out_file);
     if (outcome != FORT_OUTCOME_OK) {
-        eprintln("error: failed to compile program");
+        fort_log(LOG_ERROR, "failed to compile program");
 
         return outcome;
     }
@@ -283,7 +283,7 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
 
-    eprintln("stage: " FMTstage, ARGstage(opts.stage));
+    fort_log(LOG_DEBUG, "compilation stage: " FMTstage, ARGstage(opts.stage));
     switch (opts.stage) {
     case STAGE_LEX: {
         tok_stream_t toks = {0};
@@ -312,7 +312,7 @@ int main(int argc, char* argv[]) {
         filepath_t out_file = {0};
         outcome = compute_out_file(opts.filepath, &out_file);
         if (outcome != FORT_OUTCOME_OK) {
-            eprintln("could not compute output filename");
+            fort_log(LOG_ERROR, "could not compute output filename");
             exit_code = EXIT_FAILURE;
             break;
         }


### PR DESCRIPTION
Provides the basic infrastructure for a level-based text logger. Debug logs are only printed when running a debug build; future changes may implement a level knob to control verbosity.