### PR TITLE
ch2: Parse unary expressions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -misc-include-cleaner,
+  -misc-no-recursion,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-macro-usage

--- a/src/fort.c
+++ b/src/fort.c
@@ -169,6 +169,7 @@ static fort_outcome_t stage_codegen(const char* src, asm_prog_t* asm_prog) {
     }
 
     assembler_t* assembler = mkassembler(&prog);
+    prog_fini(&prog);
     outcome = assembler_run(assembler, asm_prog);
     assembler_fini(assembler);
 
@@ -296,6 +297,7 @@ int main(int argc, char* argv[]) {
     case STAGE_PARSE: {
         prog_t prog = {0};
         outcome = stage_parse(src, &prog);
+        prog_fini(&prog);
         exit_code = outcome == FORT_OUTCOME_OK ? EXIT_SUCCESS : EXIT_FAILURE;
         break;
     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>  // for int32_t, INT32_MAX
 #include <stdlib.h>    // for NULL, free, malloc, size_t
 
+#include "common.h"
 #include "lex.h"       // for tok_stream_t, tok_t, TOKT_CLOSE_BRACE, TOKT_CL...
 
 typedef enum {
@@ -26,7 +27,7 @@ struct parser {
     tok_stream_t* toks;
 };
 
-static fort_outcome_t consume_tok(tok_stream_t* toks, tok_t* tok) {
+static fort_outcome_t peek_tok(tok_stream_t* toks, tok_t* tok) {
     if (toks == NULL) {
         return FORT_OUTCOME_FATAL;
     }
@@ -38,6 +39,13 @@ static fort_outcome_t consume_tok(tok_stream_t* toks, tok_t* tok) {
     if (tok != NULL) {
         *tok = *toks->next;
     }
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t consume_tok(tok_stream_t* toks, tok_t* tok) {
+    fort_outcome_t outcome = peek_tok(toks, tok);
+    FORT_OUTCOME_NOK_RET(outcome);
 
     toks->next = toks->next->next;
 
@@ -93,8 +101,9 @@ static fort_outcome_t parse_int32(const char* p, size_t len, int32_t* num) {
     return FORT_OUTCOME_OK;
 }
 
-static fort_outcome_t parse_expr(tok_stream_t* toks, expr_t* expr) {
+static fort_outcome_t parse_constant(tok_stream_t* toks, expr_t* expr) {
     fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
     tok_t tok = {0};
     outcome = expect(toks, TOKT_CONSTANT, &tok);
     FORT_OUTCOME_NOK_RET(outcome);
@@ -107,8 +116,80 @@ static fort_outcome_t parse_expr(tok_stream_t* toks, expr_t* expr) {
     return FORT_OUTCOME_OK;
 }
 
+static fort_outcome_t parse_expr(tok_stream_t* toks, expr_t* expr);
+
+static fort_outcome_t parse_unary_expr(tok_stream_t* toks, expr_t* expr) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
+    tok_t tok = {0};
+    outcome = consume_tok(toks, &tok);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    if (tok.type != TOKT_TILDE && tok.type != TOKT_MINUS) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    expr_t* operand = malloc(sizeof(expr_t));
+    if (operand == NULL) {
+        return FORT_OUTCOME_FATAL;
+    }
+
+    outcome = parse_expr(toks, operand);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    expr->kind = EXPR_UNARY;
+    expr->u.unary.op = tok.type == TOKT_TILDE ? UNOP_COMPLEMENT : UNOP_NEGATE;
+    expr->u.unary.expr = operand;
+
+    return FORT_OUTCOME_OK;
+}
+
+static fort_outcome_t parse_expr(tok_stream_t* toks, expr_t* expr) {
+    fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
+    tok_t tok = {0};
+    outcome = peek_tok(toks, &tok);
+    FORT_OUTCOME_NOK_RET(outcome);
+
+    switch (tok.type) {
+    case TOKT_CONSTANT:
+        outcome = parse_constant(toks, expr);
+        break;
+    case TOKT_TILDE:
+    case TOKT_MINUS: {
+        outcome = parse_unary_expr(toks, expr);
+        break;
+    }
+    case TOKT_OPEN_PAREN: {
+        outcome = parse_expr(toks, expr);
+        FORT_OUTCOME_NOK_RET(outcome);
+
+        outcome = expect(toks, TOKT_CLOSE_PAREN, NULL);
+        FORT_OUTCOME_NOK_RET(outcome);
+        break;
+    }
+    default:
+        return FORT_OUTCOME_ERR;
+        break;
+    }
+
+    return outcome;
+}
+
+static void expr_fini(expr_t* expr) {
+    switch (expr->kind) {
+    case EXPR_CONST:
+        break;
+    case EXPR_UNARY:
+        expr_fini(expr->u.unary.expr);
+        free(expr->u.unary.expr);
+        break;
+    }
+}
+
 static fort_outcome_t parse_stmt(tok_stream_t* toks, stmt_t* stmt) {
     fort_outcome_t outcome = FORT_OUTCOME_FATAL;
+
     outcome = expect(toks, TOKT_KEYWORD_RETURN, NULL);
     FORT_OUTCOME_NOK_RET(outcome);
     stmt->kind = STMT_RET;
@@ -120,6 +201,14 @@ static fort_outcome_t parse_stmt(tok_stream_t* toks, stmt_t* stmt) {
     FORT_OUTCOME_NOK_RET(outcome);
 
     return FORT_OUTCOME_OK;
+}
+
+static void stmt_fini(stmt_t* stmt) {
+    switch (stmt->kind) {
+    case STMT_RET:
+        expr_fini(&stmt->u.ret.expr);
+        break;
+    }
 }
 
 static fort_outcome_t parse_func(tok_stream_t* toks, func_t* func) {
@@ -154,6 +243,10 @@ static fort_outcome_t parse_func(tok_stream_t* toks, func_t* func) {
     return FORT_OUTCOME_OK;
 }
 
+static void func_fini(func_t* func) {
+    stmt_fini(&func->body);
+}
+
 static fort_outcome_t parse_prog(tok_stream_t* toks, prog_t* prog) {
     fort_outcome_t outcome = FORT_OUTCOME_FATAL;
 
@@ -168,6 +261,10 @@ static fort_outcome_t parse_prog(tok_stream_t* toks, prog_t* prog) {
     FORT_OUTCOME_NOK_RET(outcome);
 
     return FORT_OUTCOME_OK;
+}
+
+void prog_fini(prog_t* prog) {
+    func_fini(&prog->func);
 }
 
 parser_t* mkparser(tok_stream_t* toks) {

--- a/src/parse.h
+++ b/src/parse.h
@@ -10,13 +10,23 @@ typedef struct parser parser_t;
 
 typedef enum {
     EXPR_CONST,
+    EXPR_UNARY,
 } expr_kind_t;
 
-typedef struct {
+typedef enum {
+    UNOP_COMPLEMENT,
+    UNOP_NEGATE,
+} unop_t;
+
+typedef struct expr {
     union {
         struct {
             int32_t val;
         } constant;
+        struct {
+            unop_t op;
+            struct expr* expr;
+        } unary;
     } u;
     expr_kind_t kind;
 } expr_t;
@@ -48,5 +58,7 @@ parser_t* mkparser(tok_stream_t* toks);
 void parser_fini(parser_t* parser);
 
 fort_outcome_t parser_run(parser_t* parser, prog_t* prog);
+
+void prog_fini(prog_t* prog);
 
 #endif // FORT_PARSE_H

--- a/test/cli-test.sh
+++ b/test/cli-test.sh
@@ -9,6 +9,6 @@ CLI_TESTS=$CLI_TESTS_DIR/test_compiler
 FORT="$PROJECT_ROOT"/build/fort
 
 CHAPTER=2
-STAGE=lex
+STAGE=parse
 
 $CLI_TESTS $FORT --chapter $CHAPTER --stage $STAGE

--- a/test/parse_test.c
+++ b/test/parse_test.c
@@ -22,6 +22,7 @@ TEST(simple_program, {
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 0);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -43,6 +44,7 @@ TEST(return_42, {
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 42);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -64,6 +66,7 @@ TEST(return_large_number, {
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_CONST);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 2147483647);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -82,6 +85,7 @@ TEST(overflow_constant, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -101,6 +105,7 @@ TEST(with_whitespace, {
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 100);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -123,6 +128,7 @@ TEST(with_comments, {
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 42);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -144,6 +150,7 @@ TEST(multiline_program, {
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
     TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.constant.val, 7);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -162,6 +169,7 @@ TEST(missing_return_keyword, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -180,6 +188,7 @@ TEST(missing_semicolon, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);  // propagates outcome from expect
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -198,6 +207,7 @@ TEST(missing_expression, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -216,6 +226,7 @@ TEST(missing_open_brace, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -234,6 +245,7 @@ TEST(missing_close_brace, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -252,6 +264,7 @@ TEST(missing_void_keyword, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -270,6 +283,7 @@ TEST(wrong_return_type, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -288,6 +302,7 @@ TEST(missing_function_name, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -306,6 +321,7 @@ TEST(empty_input, {
 
     TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_ERR);
 
+    prog_fini(&prog);
     parser_fini(parser);
     tok_stream_fini(&toks);
     lexer_fini(lexer);
@@ -335,6 +351,212 @@ TEST(null_prog, {
     lexer_fini(lexer);
 })
 
+TEST(unary_complement, {
+    const char* src = "i32 main(void) { return ~42; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.op, UNOP_COMPLEMENT);
+    TEST_ASSERT_NONNULL(prog.func.body.u.ret.expr.u.unary.expr);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.expr->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.expr->u.constant.val, 42);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(unary_negate, {
+    const char* src = "i32 main(void) { return -42; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.op, UNOP_NEGATE);
+    TEST_ASSERT_NONNULL(prog.func.body.u.ret.expr.u.unary.expr);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.expr->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.expr->u.constant.val, 42);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(nested_unary_complement_negate, {
+    const char* src = "i32 main(void) { return ~-100; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+
+    expr_t* outer = &prog.func.body.u.ret.expr;
+    TEST_ASSERT_EQ_INT32(outer->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(outer->u.unary.op, UNOP_COMPLEMENT);
+
+    expr_t* inner = outer->u.unary.expr;
+    TEST_ASSERT_NONNULL(inner);
+    TEST_ASSERT_EQ_INT32(inner->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(inner->u.unary.op, UNOP_NEGATE);
+
+    expr_t* constant = inner->u.unary.expr;
+    TEST_ASSERT_NONNULL(constant);
+    TEST_ASSERT_EQ_INT32(constant->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(constant->u.constant.val, 100);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(nested_unary_negate_complement, {
+    const char* src = "i32 main(void) { return -~7; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.kind, STMT_RET);
+
+    expr_t* outer = &prog.func.body.u.ret.expr;
+    TEST_ASSERT_EQ_INT32(outer->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(outer->u.unary.op, UNOP_NEGATE);
+
+    expr_t* inner = outer->u.unary.expr;
+    TEST_ASSERT_NONNULL(inner);
+    TEST_ASSERT_EQ_INT32(inner->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(inner->u.unary.op, UNOP_COMPLEMENT);
+
+    expr_t* constant = inner->u.unary.expr;
+    TEST_ASSERT_NONNULL(constant);
+    TEST_ASSERT_EQ_INT32(constant->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(constant->u.constant.val, 7);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(double_complement, {
+    const char* src = "i32 main(void) { return ~~5; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    expr_t* outer = &prog.func.body.u.ret.expr;
+    TEST_ASSERT_EQ_INT32(outer->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(outer->u.unary.op, UNOP_COMPLEMENT);
+
+    expr_t* inner = outer->u.unary.expr;
+    TEST_ASSERT_NONNULL(inner);
+    TEST_ASSERT_EQ_INT32(inner->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(inner->u.unary.op, UNOP_COMPLEMENT);
+
+    expr_t* constant = inner->u.unary.expr;
+    TEST_ASSERT_NONNULL(constant);
+    TEST_ASSERT_EQ_INT32(constant->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(constant->u.constant.val, 5);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(double_negate, {
+    const char* src = "i32 main(void) { return - -8; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+
+    expr_t* outer = &prog.func.body.u.ret.expr;
+    TEST_ASSERT_EQ_INT32(outer->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(outer->u.unary.op, UNOP_NEGATE);
+
+    expr_t* inner = outer->u.unary.expr;
+    TEST_ASSERT_NONNULL(inner);
+    TEST_ASSERT_EQ_INT32(inner->kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(inner->u.unary.op, UNOP_NEGATE);
+
+    expr_t* constant = inner->u.unary.expr;
+    TEST_ASSERT_NONNULL(constant);
+    TEST_ASSERT_EQ_INT32(constant->kind, EXPR_CONST);
+    TEST_ASSERT_EQ_INT32(constant->u.constant.val, 8);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
+TEST(unary_with_whitespace, {
+    const char* src = "i32 main(void) { return  ~  42  ; }";
+    lexer_t* lexer = mklexer(src, strlen(src));
+    tok_stream_t toks = {0};
+    fort_outcome_t lex_outcome = lexer_run(lexer, &toks);
+    TEST_ASSERT_EQ_INT32(lex_outcome, FORT_OUTCOME_OK);
+    parser_t* parser = mkparser(&toks);
+
+    prog_t prog = {0};
+    fort_outcome_t outcome = parser_run(parser, &prog);
+
+    TEST_ASSERT_EQ_INT32(outcome, FORT_OUTCOME_OK);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.kind, EXPR_UNARY);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.op, UNOP_COMPLEMENT);
+    TEST_ASSERT_EQ_INT32(prog.func.body.u.ret.expr.u.unary.expr->u.constant.val, 42);
+
+    prog_fini(&prog);
+    parser_fini(parser);
+    tok_stream_fini(&toks);
+    lexer_fini(lexer);
+})
+
 int main(int argc, char* argv[]) {
     TEST_INIT("parse", argc, argv);
 
@@ -356,6 +578,13 @@ int main(int argc, char* argv[]) {
     TEST_RUN(empty_input);
     TEST_RUN(null_parser);
     TEST_RUN(null_prog);
+    TEST_RUN(unary_complement);
+    TEST_RUN(unary_negate);
+    TEST_RUN(nested_unary_complement_negate);
+    TEST_RUN(nested_unary_negate_complement);
+    TEST_RUN(double_complement);
+    TEST_RUN(double_negate);
+    TEST_RUN(unary_with_whitespace);
 
     TEST_EXIT();
 }


### PR DESCRIPTION
More importantly, expressions are now allocated (in part) dynamically and so one must free up these resources.